### PR TITLE
[BUG] Fixed the  SystemCheckError

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -126,5 +126,5 @@ STATIC_URL = '/static/'
 
 # we whitelist localhost:3000 because that's where frontend will be served
 CORS_ORIGIN_WHITELIST = (
-     'localhost:3000/'
+     'http://localhost:3000',
  )


### PR DESCRIPTION
?: (corsheaders.E013) Origin '/' in CORS_ORIGIN_WHITELIST is missing  scheme or netloc
	HINT: Add a scheme (e.g. https://) or netloc (e.g. example.com).